### PR TITLE
Reduce the Flatpak size

### DIFF
--- a/im.kaidan.kaidan.json
+++ b/im.kaidan.kaidan.json
@@ -5,6 +5,7 @@
     "runtime-version": "6.10",
     "sdk": "org.kde.Sdk",
     "command": "kaidan",
+    "separate-locales": false,
     "finish-args": [
         "--device=all",
         "--device=dri",
@@ -18,7 +19,16 @@
         "--talk-name=org.freedesktop.Notifications",
         "--talk-name=org.freedesktop.secrets"
     ],
-    "separate-locales": false,
+    "cleanup": [
+        "/include",
+        "/lib/cmake",
+        "/lib/pkgconfig",
+        "/mkspecs",
+        "/share/doc",
+        "/share/qlogging-categories6",
+        "*.la",
+        "*.a"
+    ],
     "modules": [
         {
             "name": "kdsingleapplication",
@@ -98,11 +108,6 @@
                 "-DLIB_INSTALL_DIR=/app/lib",
                 "-DBUILD_TRANSLATIONS=NO",
                 "-DBUILD_WITH_QT6=ON"
-            ],
-            "cleanup": [
-                "/include",
-                "/lib/cmake",
-                "/mkspecs"
             ]
         },
         {
@@ -126,11 +131,6 @@
                         "url-template": "https://download.kde.org/unstable/qxmpp/qxmpp-$version.tar.xz"
                     }
                 }
-            ],
-            "cleanup": [
-                "/include",
-                "/lib/cmake",
-                "/lib/pkgconfig"
             ],
             "modules": [
                 {


### PR DESCRIPTION
The installed size reduced from 16.0 MB to 15.8 MB.

Not a big gain, but at least we can manage the cleanup commands together.