### PR TITLE
Revert runtime to version 6.10

### DIFF
--- a/im.kaidan.kaidan.json
+++ b/im.kaidan.kaidan.json
@@ -2,7 +2,7 @@
     "id": "im.kaidan.kaidan",
     "rename-icon": "kaidan",
     "runtime": "org.kde.Platform",
-    "runtime-version": "6.11",
+    "runtime-version": "6.10",
     "sdk": "org.kde.Sdk",
     "command": "kaidan",
     "separate-locales": false,


### PR DESCRIPTION
The `org.kde.Platform//6.11` runtime ships an **empty CA trust store** (`/etc/pki/ca-trust/extracted/` contains only READMEs — no `tls-ca-bundle.pem` and no `directory-hash`, so every `/etc/ssl` cert symlink dangles). As a result every TLS connection fails with *"The issuer certificate of a locally looked up certificate could not be found"* and Kaidan cannot connect to any server.

Qt 6.11 loads CA certificates only from hardcoded paths and ignores `SSL_CERT_FILE`/`SSL_CERT_DIR`, so there is no in-app workaround. Building against 6.10 (whose runtime bundles the CA certificates) restores connectivity — verified with a local build that completes the TLS handshake and reaches SASL authentication.

Revert to 6.10 until the runtime is fixed upstream in flatpak-kde-runtime. Reverts 84cbcf2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)